### PR TITLE
A fix for cases like iCloud where the username is an email address

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -3,6 +3,15 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="con" path="org.maven.ide.eclipse.MAVEN2_CLASSPATH_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/.project
+++ b/.project
@@ -15,8 +15,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.maven.ide.eclipse.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,5 +1,6 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=1.6

--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/README.md
+++ b/README.md
@@ -98,34 +98,24 @@ Copyright 2013 Jan Ambrož, Tomáš Balíček, Tomáš Krásný, Jindřich Pouba
 For connection to the server, user must provide the application with name or address of the server, user name and password. Connection itself realizes an instance of the `HTTPSConnection` class. Example of basic constructor usage, with server `mail.company.tld`, user name `admin` and password `123456`:
 	
 ```java
-HTTPSConnection connection = new HTTPSConnection("mail.company.tld", "admin", "123456");
+DavStore store = new DavStore("user@something.com", "password");
 ```
 
-This will create a server connection. For secure communication is used HTTPS. If the server SSL certificate is not already installed in the client TrustStore or is not signed by an certification authority, it is created and saved. To disable this function (i.e. to not create an connection, if the certificate is not trusted), user can call the more advanced constructor:
+This will attempt to use auto-discovery for the user. Auto-discovery needs a TXT or SRV DNS entry to locate the server. An example of a service that offers auto-discovery it is iCloud.
+If auto-discovery is not working, you will get an DavStoreException and you should ask the user for an URL to their CalDAV server (see the next constructor).
 	
 ```java
-HTTPSConnection connection = new HTTPSConnection("mail.company.tld", "admin", "123456",  433, false);
+DavStore store = new DavStore("user", "password", "https://server/something");
 ```
 
-where the last attribute means **do not create the connection, if the certificate is not trusted already**. The attribute `433` specifies port for the connection. Default for HTTPS and for our library is 443, but with this advanced constructors, user can specify his own.
-Default value for downloading certificates is `true`, so calling 
-
-```java	
-HTTPSConnection connection = new HTTPSConnection("mail.company.tld", "admin", "123456", 433, true);
-```
-
-has the same meaning as:
-
-```java
-HTTPSConnection connection = new HTTPSConnection("mail.company.tld", "admin", "123456");
-```
+This constructor needs an URL to the CalDAV server. For example, for a Kerio Connect server, it would be https://MyServer/caldav
 
 ### Terminating server connection
 
-For termination of connection user must call the function `shutdown()` on top of instance of that connection, that will get terminated. For example, to terminate the connection used in previous example:
+For termination of connection user must call the function `disconnect()` on top of instance of that connection, that will get terminated. For example, to terminate the connection used in previous example:
 
 ```java	
-connection.shutdown();
+store.shutdown();
 ```
 
 It's highly recommended to terminate every created connection.

--- a/src/zswi/protocols/communication/core/DavStore.java
+++ b/src/zswi/protocols/communication/core/DavStore.java
@@ -718,7 +718,49 @@ public class DavStore {
     }
     return response;
   }
+  
+  public static String calendarMultiGetReport(HTTPConnectionManager connectionManager, String path, String xmlContent, int depth) throws DavStoreException, NotImplemented {
+    ReportRequest req;
+    String response = "";
+    StringEntity body = null;
+    try {
+      body = new StringEntity(xmlContent);
+    }
+    catch (UnsupportedEncodingException e1) {
+      e1.printStackTrace();
+    }
+    
+    try {
+      req = new ReportRequest(connectionManager.initUri(path), depth);
+      body.setContentType("text/xml");
+      req.setEntity(body);
 
+      HttpResponse resp = connectionManager.getHttpClient().execute(req);
+
+      if (resp.getStatusLine().getStatusCode() == 501) {
+        EntityUtils.consume(resp.getEntity());
+        throw new NotImplemented(resp.getStatusLine().getReasonPhrase());
+      } else if (resp.getStatusLine().getStatusCode() >= 400) {
+        EntityUtils.consume(resp.getEntity());
+        throw new DavStoreException(resp.getStatusLine().getReasonPhrase());
+      }
+
+      response += EntityUtils.toString(resp.getEntity());
+
+      EntityUtils.consume(resp.getEntity());
+    }
+    catch (UnsupportedEncodingException e) {
+      throw new DavStoreException(e.getMessage());
+    }
+    catch (URISyntaxException e) {
+      throw new DavStoreException(e.getMessage());
+    }
+    catch (IOException e) {
+      throw new DavStoreException(e.getMessage());
+    }
+
+    return response;
+  }
   /**
    * TODO this method should be called each a collection is called, and the features/allowed methods should be stored inside the collection data structure
    * 

--- a/src/zswi/protocols/communication/core/DavStore.java
+++ b/src/zswi/protocols/communication/core/DavStore.java
@@ -119,6 +119,14 @@ public class DavStore {
         checkWellKnownUrl();
       } catch (NoRedirectFoundException e) {
         logger.info(e.getMessage());
+        logger.info("Let's retry with username@domain");
+        connectionManager.closeConnection();
+        connectionManager.setUsername(connectionManager.getUsername() + "@" + connectionManager.getDomain());
+        try {
+          checkWellKnownUrl();
+        } catch (NoRedirectFoundException e2) {
+          logger.info(e2.getMessage());
+        }
       }
     } 
 

--- a/src/zswi/schemas/dav/icalendarobjects/Prop.java
+++ b/src/zswi/schemas/dav/icalendarobjects/Prop.java
@@ -42,7 +42,8 @@ import javax.xml.bind.annotation.XmlType;
 @XmlType(name = "", propOrder = {
     "bogusElement",
     "getetag",
-    "calendarData"
+    "calendarData",
+    "getcontenttype"
 })
 @XmlRootElement(name = "prop")
 public class Prop {
@@ -51,6 +52,7 @@ public class Prop {
     protected String getetag;
     @XmlElement(name = "calendar-data", namespace = "urn:ietf:params:xml:ns:caldav")
     protected String calendarData;
+    protected String getcontenttype;
 
     /**
      * Gets the value of the bogusElement property.
@@ -122,6 +124,30 @@ public class Prop {
      */
     public void setCalendarData(String value) {
         this.calendarData = value;
+    }
+    
+    /**
+     * Gets the value of the getetag property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getGetcontenttype() {
+        return getcontenttype;
+    }
+
+    /**
+     * Sets the value of the getetag property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setGetcontenttype(String value) {
+        this.getcontenttype = value;
     }
 
 }


### PR DESCRIPTION
Auto-discovery didn't work correctly for iCloud because the username needs to be an email address. It will now try to authenticate with both just the username, or with username@domain