### PR TITLE
Changed InputStream setup to the thread's context classloader.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 # Build files
 target
 bin
+/.settings/
+/.classpath
+/.project

--- a/src/zswi/objects/dav/collections/AddressBookCollection.java
+++ b/src/zswi/objects/dav/collections/AddressBookCollection.java
@@ -128,7 +128,9 @@ public class AddressBookCollection extends AbstractNotPrincipalCollection {
     PropfindRequest req;
     try {
       req = new PropfindRequest(connectionManager.initUri(collection.getUri()), 1);
-      InputStream is = ClassLoader.getSystemResourceAsStream("propfind-etag-request.xml");
+			ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+			InputStream is = classLoader.getResourceAsStream("propfind-etag-request.xml");
+//      InputStream is = ClassLoader.getSystemResourceAsStream("propfind-etag-request.xml");
 
       StringEntity se = new StringEntity(Utilities.convertStreamToString(is));
 

--- a/src/zswi/objects/dav/collections/AddressBookHomeSet.java
+++ b/src/zswi/objects/dav/collections/AddressBookHomeSet.java
@@ -28,7 +28,9 @@ public class AddressBookHomeSet extends AbstractHomeSetCollection {
 
   public AddressBookHomeSet(HTTPConnectionManager connectionManager, PrincipalCollection principals, URI uriForRequest) throws JAXBException, ClientProtocolException, IOException, URISyntaxException {
     PropfindRequest req = new PropfindRequest(uriForRequest, 1);
-    InputStream is = ClassLoader.getSystemResourceAsStream("props-adressbookhomeset-request.xml");
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		InputStream is = classLoader.getResourceAsStream("props-adressbookhomeset-request.xml");
+//    InputStream is = ClassLoader.getSystemResourceAsStream("props-adressbookhomeset-request.xml");
 
     StringEntity se = new StringEntity(convertStreamToString(is));
 

--- a/src/zswi/objects/dav/collections/CalendarCollection.java
+++ b/src/zswi/objects/dav/collections/CalendarCollection.java
@@ -459,7 +459,9 @@ public class CalendarCollection extends AbstractNotPrincipalCollection implement
           try {
             URL propfindUrl = new URL(connectionManager.httpScheme(), connectionManager.getServerName(), connectionManager.getPort(), path);
             PropfindRequest propFindRequest = new PropfindRequest(propfindUrl.toURI(), 0);
-            InputStream is = ClassLoader.getSystemResourceAsStream("propfind-etag-request.xml");
+        		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        		InputStream is = classLoader.getResourceAsStream("propfind-etag-request.xml");            
+//            InputStream is = ClassLoader.getSystemResourceAsStream("propfind-etag-request.xml");
 
             StringEntity propFindBoby = new StringEntity(Utilities.convertStreamToString(is));
 

--- a/src/zswi/objects/dav/collections/CalendarHomeSet.java
+++ b/src/zswi/objects/dav/collections/CalendarHomeSet.java
@@ -51,7 +51,9 @@ public class CalendarHomeSet extends AbstractHomeSetCollection {
   
   public CalendarHomeSet(HTTPConnectionManager connectionManager, PrincipalCollection principals, URI uriForRequest) throws JAXBException, ClientProtocolException, IOException, URISyntaxException, ParserException {
     PropfindRequest req = new PropfindRequest(uriForRequest, 1);
-    InputStream is = ClassLoader.getSystemResourceAsStream("props-calendarhomeset-request.xml");
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		InputStream is = classLoader.getResourceAsStream("props-calendarhomeset-request.xml");            
+//    InputStream is = ClassLoader.getSystemResourceAsStream("props-calendarhomeset-request.xml");
 
     StringEntity se = new StringEntity(convertStreamToString(is));
 

--- a/src/zswi/objects/dav/collections/InboxCollection.java
+++ b/src/zswi/objects/dav/collections/InboxCollection.java
@@ -25,7 +25,9 @@ public class InboxCollection extends AbstractNotPrincipalCollection {
   
   public InboxCollection(DefaultHttpClient _httpClient, PrincipalCollection principals, URI uriForRequest) throws JAXBException, ClientProtocolException, IOException, URISyntaxException {
     PropfindRequest req = new PropfindRequest(uriForRequest, 0);
-    InputStream is = ClassLoader.getSystemResourceAsStream("rfc6638-request.xml");
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		InputStream is = classLoader.getResourceAsStream("rfc6638-request.xml");            
+//    InputStream is = ClassLoader.getSystemResourceAsStream("rfc6638-request.xml");
 
     StringEntity se = new StringEntity(convertStreamToString(is));
 

--- a/src/zswi/objects/dav/collections/OutboxCollection.java
+++ b/src/zswi/objects/dav/collections/OutboxCollection.java
@@ -21,7 +21,9 @@ public class OutboxCollection extends AbstractNotPrincipalCollection {
 
   public OutboxCollection(DefaultHttpClient _httpClient, PrincipalCollection principals, URI uriForRequest) throws JAXBException, ClientProtocolException, IOException, URISyntaxException {
     PropfindRequest req = new PropfindRequest(uriForRequest, 1);
-    InputStream is = ClassLoader.getSystemResourceAsStream("rfc6638-request.xml");
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		InputStream is = classLoader.getResourceAsStream("rfc6638-request.xml");            
+//    InputStream is = ClassLoader.getSystemResourceAsStream("rfc6638-request.xml");
 
     StringEntity se = new StringEntity(convertStreamToString(is));
 

--- a/src/zswi/objects/dav/collections/PrincipalCollection.java
+++ b/src/zswi/objects/dav/collections/PrincipalCollection.java
@@ -96,7 +96,9 @@ public class PrincipalCollection extends AbstractDavCollection {
   public PrincipalCollection(DavStore store, URI uri, boolean isFakePrincipals, boolean isFirstLevel) throws JAXBException, URISyntaxException, ClientProtocolException, IOException {
     
     PropfindRequest req = new PropfindRequest(uri, 0);
-    InputStream is = ClassLoader.getSystemResourceAsStream("userinfo-request.xml");
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		InputStream is = classLoader.getResourceAsStream("userinfo-request.xml");            
+//    InputStream is = ClassLoader.getSystemResourceAsStream("userinfo-request.xml");
 
     StringEntity se = new StringEntity(Utilities.convertStreamToString(is));
 
@@ -166,7 +168,9 @@ public class PrincipalCollection extends AbstractDavCollection {
     ReportRequest req;
     try {
       req = new ReportRequest(store.initUri(uri), 0);
-      InputStream is = ClassLoader.getSystemResourceAsStream("calendar-proxies-request.xml");
+  		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+  		InputStream is = classLoader.getResourceAsStream("calendar-proxies-request.xml");            
+//      InputStream is = ClassLoader.getSystemResourceAsStream("calendar-proxies-request.xml");
 
       StringEntity se = new StringEntity(Utilities.convertStreamToString(is));
 

--- a/src/zswi/protocols/communication/core/DavStore.java
+++ b/src/zswi/protocols/communication/core/DavStore.java
@@ -260,7 +260,9 @@ public class DavStore {
     try {
       URL urlForRequest = new URL(httpScheme(), connectionManager.getServerName(), connectionManager.getPort(), "/.well-known/caldav");
       req = new PropfindRequest(urlForRequest.toURI(), 0);
-      InputStream is = ClassLoader.getSystemResourceAsStream("well-known-request.xml");
+  		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+  		InputStream is = classLoader.getResourceAsStream("well-known-request.xml");            
+//      InputStream is = ClassLoader.getSystemResourceAsStream("well-known-request.xml");
 
       StringEntity se = new StringEntity(Utilities.convertStreamToString(is));
 
@@ -313,7 +315,9 @@ public class DavStore {
     try {
       URI urlForRequest = initUri(path);
       req = new PropfindRequest(urlForRequest, 0);
-      InputStream is = ClassLoader.getSystemResourceAsStream("well-known-request.xml");
+  		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+  		InputStream is = classLoader.getResourceAsStream("well-known-request.xml");            
+//      InputStream is = ClassLoader.getSystemResourceAsStream("well-known-request.xml");
 
       StringEntity se = new StringEntity(Utilities.convertStreamToString(is));
 
@@ -707,7 +711,9 @@ public class DavStore {
 
   public static String report(HTTPConnectionManager connectionManager, String filename, String path, int depth) throws DavStoreException, NotImplemented {
     String response = "";
-    InputStream is = ClassLoader.getSystemResourceAsStream(filename);
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		InputStream is = classLoader.getResourceAsStream(filename);            
+//    InputStream is = ClassLoader.getSystemResourceAsStream(filename);
     StringEntity se;
     try {
       se = new StringEntity(Utilities.convertStreamToString(is));

--- a/src/zswi/protocols/communication/core/HTTPSConnection.java
+++ b/src/zswi/protocols/communication/core/HTTPSConnection.java
@@ -25,6 +25,7 @@ import java.security.KeyStore;
 import java.util.List;
 
 import javax.xml.parsers.ParserConfigurationException;
+
 import net.fortuna.ical4j.data.ParserException;
 import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.component.VEvent;
@@ -474,7 +475,9 @@ public class HTTPSConnection {
 	private String report(String filename, String path, int depth) throws ClientProtocolException, IOException, URISyntaxException {
 		ReportRequest req = new ReportRequest(initUri(path), depth);
 
-		InputStream is = ClassLoader.getSystemResourceAsStream(filename);
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		InputStream is = classLoader.getResourceAsStream(filename);            
+//		InputStream is = ClassLoader.getSystemResourceAsStream(filename);
 
 		StringEntity se = new StringEntity(convertStreamToString(is));
 		
@@ -500,7 +503,9 @@ public class HTTPSConnection {
 	private String propfind(String fileName, String uriName) throws URISyntaxException, ClientProtocolException, IOException {
 
 		PropfindRequest req = new PropfindRequest(initUri(uriName));
-		InputStream is = ClassLoader.getSystemResourceAsStream(fileName);
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		InputStream is = classLoader.getResourceAsStream(fileName);            
+//		InputStream is = ClassLoader.getSystemResourceAsStream(fileName);
 		
 		StringEntity se = new StringEntity(convertStreamToString(is));
 		


### PR DESCRIPTION
This modification enables cdav-connector library to be used in server
and portlet applications, too.

We use your library in a portlet used to manage calendar and contact synchronization with Liferay (see https://github.com/inofix/liferay-modules). In order to use the library, we had to change your InputStream setup, so that it works in Servlet / PortletContexts, too. 

As far as we understand, this modification should not have any drawbacks to your default usage scenarios but extend the library's application range. 

Additionally, we would suggest to increase the version number in maven, since the library looks quite stable. More stable at least, than what you would expect from version 0.0.1. 

Best, 

Christian
 